### PR TITLE
Allow ability to return object for start request from Rex

### DIFF
--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/Adapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/Adapter.java
@@ -10,6 +10,7 @@ import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
 import java.net.URI;
+import java.util.Optional;
 
 /**
  * Interface for all the adapters
@@ -22,9 +23,12 @@ public interface Adapter<T> {
     /**
      * Translates the Rex StartRequest DTO to the application's DTO and send the request to the application
      *
+     * You can optionally return an object that will be sent to the sender (Rex). This is useful if you want to return a
+     * unique id that the start method has obtained from the application
+     * 
      * @param startRequest
      */
-    void start(String correlationId, StartRequest startRequest);
+    Optional<Object> start(String correlationId, StartRequest startRequest);
 
     /**
      * Translates the callback from the application's DTO and send it back to Rex

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/CausewayBrewPushAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/CausewayBrewPushAdapter.java
@@ -6,6 +6,8 @@ import org.jboss.pnc.dingrogu.api.endpoint.WorkflowEndpoint;
 import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
+import java.util.Optional;
+
 @ApplicationScoped
 public class CausewayBrewPushAdapter implements Adapter<BrewPushDTO> {
 
@@ -15,7 +17,7 @@ public class CausewayBrewPushAdapter implements Adapter<BrewPushDTO> {
     }
 
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
         throw new UnsupportedOperationException();
     }
 

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/DeliverablesAnalyzerAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/DeliverablesAnalyzerAdapter.java
@@ -18,6 +18,7 @@ import org.jboss.pnc.rex.model.requests.StopRequest;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 @ApplicationScoped
 public class DeliverablesAnalyzerAdapter implements Adapter<DeliverablesAnalyzerDTO> {
@@ -40,7 +41,7 @@ public class DeliverablesAnalyzerAdapter implements Adapter<DeliverablesAnalyzer
     }
 
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
         DeliverablesAnalyzerDTO deliverablesAnalyzerDTO = objectMapper
                 .convertValue(startRequest.getPayload(), DeliverablesAnalyzerDTO.class);
 
@@ -56,6 +57,7 @@ public class DeliverablesAnalyzerAdapter implements Adapter<DeliverablesAnalyzer
                 null);
 
         deliverablesAnalyzerClient.analyze(deliverablesAnalyzerDTO.getDeliverablesAnalyzerUrl(), payload);
+        return Optional.empty();
     }
 
     @Override

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/DummyAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/DummyAdapter.java
@@ -16,6 +16,7 @@ import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Just a dummy adapter to test for Rex functionality. It does nothing and just calls the Rex callback. Supports the
@@ -38,7 +39,7 @@ public class DummyAdapter implements Adapter<DummyDTO> {
     ObjectMapper objectMapper;
 
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
         Map<String, String> mdcMap = startRequest.getMdc();
         for (String key : mdcMap.keySet()) {
             log.info("Adapter start mdc: {}::{}", key, mdcMap.get(key));
@@ -48,6 +49,8 @@ public class DummyAdapter implements Adapter<DummyDTO> {
         Log.info(startRequest.getPayload().toString());
         DummyDTO dummyDTO = objectMapper.convertValue(startRequest.getPayload(), DummyDTO.class);
         dummyClient.start(dummyDTO.getDummyServiceUrl(), callbackUrl);
+
+        return Optional.empty();
     }
 
     @Override

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/OrchDeliverablesAnalyzerResultAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/OrchDeliverablesAnalyzerResultAdapter.java
@@ -21,6 +21,7 @@ import org.jboss.pnc.rex.model.requests.StopRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.Optional;
 
 @ApplicationScoped
 public class OrchDeliverablesAnalyzerResultAdapter implements Adapter<OrchDeliverablesAnalyzerResultDTO> {
@@ -46,7 +47,7 @@ public class OrchDeliverablesAnalyzerResultAdapter implements Adapter<OrchDelive
     }
 
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
         Request callback;
         try {
             callback = new Request(
@@ -77,6 +78,8 @@ public class OrchDeliverablesAnalyzerResultAdapter implements Adapter<OrchDelive
                 .build();
 
         orchClient.submitDelAResult(dto.getOrchUrl(), result);
+
+        return Optional.empty();
     }
 
     @Override

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/OrchRepositoryCreationResultAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/OrchRepositoryCreationResultAdapter.java
@@ -18,6 +18,7 @@ import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
 import java.util.Map;
+import java.util.Optional;
 
 // TODO: replace this with rex notification
 @ApplicationScoped
@@ -47,7 +48,7 @@ public class OrchRepositoryCreationResultAdapter implements Adapter<OrchReposito
     }
 
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
 
         // grab payload DTO
         OrchRepositoryCreationResultDTO dto = objectMapper
@@ -86,6 +87,8 @@ public class OrchRepositoryCreationResultAdapter implements Adapter<OrchReposito
                 Log.error("Error happened in rex client callback to Rex server for orch repository create", e);
             }
         });
+
+        return Optional.empty();
     }
 
     @Override

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverPromoteAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverPromoteAdapter.java
@@ -19,6 +19,7 @@ import org.jboss.pnc.rex.model.requests.StopRequest;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Optional;
 
 @ApplicationScoped
 public class RepositoryDriverPromoteAdapter implements Adapter<RepositoryDriverPromoteDTO> {
@@ -47,7 +48,7 @@ public class RepositoryDriverPromoteAdapter implements Adapter<RepositoryDriverP
      * @param startRequest
      */
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
 
         Request callback;
         try {
@@ -76,6 +77,8 @@ public class RepositoryDriverPromoteAdapter implements Adapter<RepositoryDriverP
                 .build();
 
         repositoryDriverClient.promote(repoPromoteDTO.getRepositoryDriverUrl(), promoteRequest);
+
+        return Optional.empty();
     }
 
     /**

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverSealAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverSealAdapter.java
@@ -12,6 +12,8 @@ import org.jboss.pnc.rex.api.CallbackEndpoint;
 import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
+import java.util.Optional;
+
 @ApplicationScoped
 public class RepositoryDriverSealAdapter implements Adapter<RepositoryDriverSealDTO> {
 
@@ -39,7 +41,7 @@ public class RepositoryDriverSealAdapter implements Adapter<RepositoryDriverSeal
      * @param startRequest
      */
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
 
         RepositoryDriverSealDTO repositorySealDTO = objectMapper
                 .convertValue(startRequest.getPayload(), RepositoryDriverSealDTO.class);
@@ -59,6 +61,8 @@ public class RepositoryDriverSealAdapter implements Adapter<RepositoryDriverSeal
                 Log.error("Error happened in rex client callback to Rex server for repository driver seal", e);
             }
         });
+
+        return Optional.empty();
     }
 
     @Override

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverSetupAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverSetupAdapter.java
@@ -19,6 +19,7 @@ import org.jboss.pnc.rex.model.requests.StopRequest;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @ApplicationScoped
 public class RepositoryDriverSetupAdapter implements Adapter<RepositoryDriverSetupDTO> {
@@ -50,7 +51,7 @@ public class RepositoryDriverSetupAdapter implements Adapter<RepositoryDriverSet
      * @param startRequest
      */
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
 
         Map<String, Object> pastResults = startRequest.getTaskResults();
         Object pastResult = pastResults.get(reqour.getRexTaskName(correlationId));
@@ -87,6 +88,8 @@ public class RepositoryDriverSetupAdapter implements Adapter<RepositoryDriverSet
                 Log.error("Error happened in rex client callback to Rex server for repository driver create", e);
             }
         });
+
+        return Optional.empty();
     }
 
     /**

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepourAdjustAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepourAdjustAdapter.java
@@ -18,6 +18,8 @@ import org.jboss.pnc.rex.api.CallbackEndpoint;
 import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
+import java.util.Optional;
+
 @ApplicationScoped
 public class RepourAdjustAdapter implements Adapter<RepourAdjustDTO> {
 
@@ -39,7 +41,7 @@ public class RepourAdjustAdapter implements Adapter<RepourAdjustDTO> {
     }
 
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
         RepourAdjustDTO repourAdjustDTO = objectMapper.convertValue(startRequest.getPayload(), RepourAdjustDTO.class);
 
         String callbackUrl = AdapterEndpoint.getCallbackAdapterEndpoint(dingroguUrl, getAdapterName(), correlationId);
@@ -68,6 +70,8 @@ public class RepourAdjustAdapter implements Adapter<RepourAdjustDTO> {
 
         // Send to Repour
         repourClient.adjust(repourAdjustDTO.getRepourUrl(), request);
+
+        return Optional.empty();
     }
 
     @Override

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepourCloneRepositoryAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepourCloneRepositoryAdapter.java
@@ -18,6 +18,7 @@ import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
 import java.util.Map;
+import java.util.Optional;
 
 @ApplicationScoped
 public class RepourCloneRepositoryAdapter implements Adapter<RepourCloneRepositoryDTO> {
@@ -38,7 +39,7 @@ public class RepourCloneRepositoryAdapter implements Adapter<RepourCloneReposito
     RepourClient repourClient;
 
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
 
         Map<String, Object> pastResults = startRequest.getTaskResults();
         Object pastResult = pastResults.get(repourCreate.getRexTaskName(correlationId));
@@ -63,6 +64,8 @@ public class RepourCloneRepositoryAdapter implements Adapter<RepourCloneReposito
                 .build();
 
         repourClient.cloneRequest(dto.getRepourUrl(), request);
+
+        return Optional.empty();
     }
 
     @Override

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepourCreateRepositoryAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepourCreateRepositoryAdapter.java
@@ -16,6 +16,7 @@ import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
 import java.util.Collections;
+import java.util.Optional;
 
 @ApplicationScoped
 public class RepourCreateRepositoryAdapter implements Adapter<RepourCreateRepositoryDTO> {
@@ -33,7 +34,7 @@ public class RepourCreateRepositoryAdapter implements Adapter<RepourCreateReposi
     RepourClient repourClient;
 
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
         RepourCreateRepositoryDTO repourCreateDTO = objectMapper
                 .convertValue(startRequest.getPayload(), RepourCreateRepositoryDTO.class);
 
@@ -58,6 +59,8 @@ public class RepourCreateRepositoryAdapter implements Adapter<RepourCreateReposi
                 Log.error("Error happened in rex client callback to Rex server for repository driver seal", e);
             }
         });
+
+        return Optional.empty();
     }
 
     @Override

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/ReqourAdjustAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/ReqourAdjustAdapter.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @ApplicationScoped
 public class ReqourAdjustAdapter implements Adapter<ReqourAdjustDTO> {
@@ -46,7 +47,7 @@ public class ReqourAdjustAdapter implements Adapter<ReqourAdjustDTO> {
     }
 
     @Override
-    public void start(String correlationId, StartRequest startRequest) {
+    public Optional<Object> start(String correlationId, StartRequest startRequest) {
         Request callback;
         try {
             callback = new Request(
@@ -93,6 +94,8 @@ public class ReqourAdjustAdapter implements Adapter<ReqourAdjustDTO> {
 
         // Send to Reqour
         reqourClient.adjust(reqourAdjustDTO.getReqourUrl(), request);
+
+        return Optional.empty();
     }
 
     @Override

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/rest/AdapterEndpointImpl.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/rest/AdapterEndpointImpl.java
@@ -17,6 +17,7 @@ import org.jboss.pnc.rex.model.requests.StopRequest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Adapter endpoint: Each Rex task will call the Adapter endpoint for that task. The endpoint will translate the Rex DTO
@@ -68,8 +69,13 @@ public class AdapterEndpointImpl implements AdapterEndpoint {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
-        adapter.start(correlationId, startRequest);
-        return Response.accepted().build();
+        Optional<Object> response = adapter.start(correlationId, startRequest);
+
+        if (response.isEmpty()) {
+            return Response.accepted().build();
+        } else {
+            return Response.accepted(response.get()).build();
+        }
     }
 
     @Override


### PR DESCRIPTION
This will allow us to return some unique metadata from the adapter when it sent the request to the application, like a unique id for cancellation.