### PR TITLE
Adapt to getTaskResult new API

### DIFF
--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/KonfluxBuildDriverAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/KonfluxBuildDriverAdapter.java
@@ -79,9 +79,8 @@ public class KonfluxBuildDriverAdapter implements Adapter<KonfluxBuildDriverDTO>
 
         Map<String, Object> pastResults = startRequest.getTaskResults();
         Object repoDriverSetup = pastResults.get(repositoryDriverSetupAdapter.getRexTaskName(correlationId));
-        ServerResponse serverResponseRepoDriver = objectMapper.convertValue(repoDriverSetup, ServerResponse.class);
         RepositoryCreateResponse repositoryResponse = objectMapper
-                .convertValue(serverResponseRepoDriver.getBody(), RepositoryCreateResponse.class);
+                .convertValue(repoDriverSetup, RepositoryCreateResponse.class);
 
         Object alignSetup = pastResults.get(reqourAdjustAdapter.getRexTaskName(correlationId));
         ServerResponse serverResponseAlign = objectMapper.convertValue(alignSetup, ServerResponse.class);

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/OrchDeliverablesAnalyzerResultAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/OrchDeliverablesAnalyzerResultAdapter.java
@@ -14,7 +14,6 @@ import org.jboss.pnc.dingrogu.api.endpoint.WorkflowEndpoint;
 import org.jboss.pnc.dingrogu.common.TaskHelper;
 import org.jboss.pnc.dingrogu.restadapter.client.OrchClient;
 import org.jboss.pnc.rex.api.CallbackEndpoint;
-import org.jboss.pnc.rex.model.ServerResponse;
 import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
@@ -66,8 +65,7 @@ public class OrchDeliverablesAnalyzerResultAdapter implements Adapter<OrchDelive
 
         Map<String, Object> pastResults = startRequest.getTaskResults();
         Object pastResult = pastResults.get(deliverablesAnalyzerAdapter.getRexTaskName(correlationId));
-        ServerResponse serverResponse = objectMapper.convertValue(pastResult, ServerResponse.class);
-        AnalysisReport analysisReport = objectMapper.convertValue(serverResponse.getBody(), AnalysisReport.class);
+        AnalysisReport analysisReport = objectMapper.convertValue(pastResult, AnalysisReport.class);
 
         // generate result for Orch
         AnalysisResult result = AnalysisResult.builder()

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/OrchRepositoryCreationResultAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/OrchRepositoryCreationResultAdapter.java
@@ -13,7 +13,6 @@ import org.jboss.pnc.dingrogu.restadapter.client.OrchClient;
 import org.jboss.pnc.dto.tasks.RepositoryCreationResult;
 import org.jboss.pnc.enums.ResultStatus;
 import org.jboss.pnc.rex.api.CallbackEndpoint;
-import org.jboss.pnc.rex.model.ServerResponse;
 import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
@@ -56,9 +55,8 @@ public class OrchRepositoryCreationResultAdapter implements Adapter<OrchReposito
 
         Map<String, Object> pastResults = startRequest.getTaskResults();
         Object pastResult = pastResults.get(repourCreate.getRexTaskName(correlationId));
-        ServerResponse serverResponse = objectMapper.convertValue(pastResult, ServerResponse.class);
         RepourCreateRepoResponse repourCreateResponse = objectMapper
-                .convertValue(serverResponse.getBody(), RepourCreateRepoResponse.class);
+                .convertValue(pastResult, RepourCreateRepoResponse.class);
 
         // generate result for Orch
         // TODO: adjust the status

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverSetupAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverSetupAdapter.java
@@ -13,7 +13,6 @@ import org.jboss.pnc.dingrogu.api.dto.adapter.RepositoryDriverSetupDTO;
 import org.jboss.pnc.dingrogu.api.endpoint.WorkflowEndpoint;
 import org.jboss.pnc.dingrogu.restadapter.client.RepositoryDriverClient;
 import org.jboss.pnc.rex.api.CallbackEndpoint;
-import org.jboss.pnc.rex.model.ServerResponse;
 import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
@@ -55,8 +54,7 @@ public class RepositoryDriverSetupAdapter implements Adapter<RepositoryDriverSet
 
         Map<String, Object> pastResults = startRequest.getTaskResults();
         Object pastResult = pastResults.get(reqour.getRexTaskName(correlationId));
-        ServerResponse serverResponse = objectMapper.convertValue(pastResult, ServerResponse.class);
-        AdjustResponse reqourResponse = objectMapper.convertValue(serverResponse.getBody(), AdjustResponse.class);
+        AdjustResponse reqourResponse = objectMapper.convertValue(pastResult, AdjustResponse.class);
 
         List<String> repositoriesToCreate = reqourResponse.getManipulatorResult()
                 .getRemovedRepositories()

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepourCloneRepositoryAdapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepourCloneRepositoryAdapter.java
@@ -13,7 +13,6 @@ import org.jboss.pnc.dingrogu.api.endpoint.AdapterEndpoint;
 import org.jboss.pnc.dingrogu.api.endpoint.WorkflowEndpoint;
 import org.jboss.pnc.dingrogu.restadapter.client.RepourClient;
 import org.jboss.pnc.rex.api.CallbackEndpoint;
-import org.jboss.pnc.rex.model.ServerResponse;
 import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
 
@@ -43,9 +42,7 @@ public class RepourCloneRepositoryAdapter implements Adapter<RepourCloneReposito
 
         Map<String, Object> pastResults = startRequest.getTaskResults();
         Object pastResult = pastResults.get(repourCreate.getRexTaskName(correlationId));
-        ServerResponse serverResponse = objectMapper.convertValue(pastResult, ServerResponse.class);
-        RepourCreateRepoResponse repourResponse = objectMapper
-                .convertValue(serverResponse.getBody(), RepourCreateRepoResponse.class);
+        RepourCreateRepoResponse repourResponse = objectMapper.convertValue(pastResult, RepourCreateRepoResponse.class);
 
         RepourCloneRepositoryDTO dto = objectMapper
                 .convertValue(startRequest.getPayload(), RepourCloneRepositoryDTO.class);

--- a/rest-adapter/src/test/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverSetupAdapterTest.java
+++ b/rest-adapter/src/test/java/org/jboss/pnc/dingrogu/restadapter/adapter/RepositoryDriverSetupAdapterTest.java
@@ -11,7 +11,6 @@ import org.jboss.pnc.api.reqour.dto.AdjustResponse;
 import org.jboss.pnc.dingrogu.api.dto.adapter.RepositoryDriverSetupDTO;
 import org.jboss.pnc.dingrogu.restadapter.client.RepositoryDriverClient;
 import org.jboss.pnc.rex.api.CallbackEndpoint;
-import org.jboss.pnc.rex.model.ServerResponse;
 import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -57,9 +56,7 @@ public class RepositoryDriverSetupAdapterTest {
         // create reqour response
         Map<String, Object> pastResults = new HashMap<>();
         AdjustResponse adjustResponse = Instancio.create(AdjustResponse.class);
-        pastResults.put(
-                reqourAdjustAdapter.getRexTaskName(correlationId),
-                ServerResponse.builder().body(adjustResponse).build());
+        pastResults.put(reqourAdjustAdapter.getRexTaskName(correlationId), adjustResponse);
 
         StartRequest startRequest = StartRequest.builder().payload(dto).taskResults(pastResults).build();
         // when repository driver client get the request, return with a response


### PR DESCRIPTION
getTaskResult now returns the object itself, rather than the object wrapped around a `ServerResponse`

https://github.com/project-ncl/rex/pull/101