### PR TITLE
[NCL-9060] Workaround issue where dependency tasks gone

### DIFF
--- a/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/workflows/BuildWorkflow.java
+++ b/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/workflows/BuildWorkflow.java
@@ -173,6 +173,13 @@ public class BuildWorkflow implements Workflow<BuildWorkDTO> {
                     .target(taskAdjustReqour.name)
                     .build();
             EdgeDTO buildToCompleteEnv = EdgeDTO.builder().source(taskCompleteEnv.name).target(taskBuild.name).build();
+
+            // WARN: NCL-9060: dependency tasks like reqour adjust are deleted if the taskCompleteEnv has no dependents.
+            // Adding that edge artifically so that the dependency tasks are not deleted prematurely
+            EdgeDTO completeToRepoSealEnv = EdgeDTO.builder()
+                    .source(taskRepoSeal.name)
+                    .target(taskCompleteEnv.name)
+                    .build();
             EdgeDTO buildToRepoSeal = EdgeDTO.builder().source(taskRepoSeal.name).target(taskBuild.name).build();
             EdgeDTO repoSealToRepoPromote = EdgeDTO.builder()
                     .source(taskRepoPromote.name)
@@ -184,6 +191,7 @@ public class BuildWorkflow implements Workflow<BuildWorkDTO> {
                     repoSetupToCreateEnv,
                     createEnvToBuild,
                     adjustReqourToBuild,
+                    completeToRepoSealEnv,
                     buildToCompleteEnv,
                     buildToRepoSeal,
                     repoSealToRepoPromote);


### PR DESCRIPTION
Rex has an issue where the dependency tasks are deleted too eagerly if the env-driver-complete task has no dependants.

This commit adds an edge between env-driver-complete and repo-seal so that env-driver-complete task has a dependant. It is then not deleted, which means that the dependency tasks are also not deleted.

We want the dependency tasks to still be available to grab their results after the final task is finished. The results are used to send the final result to the caller.