### PR TITLE
Exclude non-jakarta pnc-api from another dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,18 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.pnc</groupId>
+                <artifactId>model</artifactId>
+                <version>${version.pnc}</version>
+                <exclusions>
+                    <!-- it's bringing in the non-jakarta pnc-api. yuck! -->
+                    <exclusion>
+                        <groupId>org.jboss.pnc</groupId>
+                        <artifactId>pnc-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
 
             <!-- OR maybe you like Jackson better? -->


### PR DESCRIPTION
With that there are warnings in the build log like: 

> [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Dependencies with duplicate files detected. The dependencies [org.jboss.pnc:pnc-api::jar:3.0.4[paths: /home/pkocandr/.m2/repository/org/jboss/pnc/pnc-api/3.0.4/pnc-api-3.0.4.jar;], org.jboss.pnc:pnc-api:jakarta:jar:3.0.6[paths: /home/pkocandr/.m2/repository/org/jboss/pnc/pnc-api/3.0.6/pnc-api-3.0.6-jakarta.jar;]] contain duplicate files, e.g. org/jboss/pnc/api/builddriver/dto/BuildRequest$Builder.class