### PR TITLE
Add taskId for scm-creation for notification on orch side

### DIFF
--- a/api/src/main/java/org/jboss/pnc/dingrogu/api/dto/workflow/RepositoryCreationDTO.java
+++ b/api/src/main/java/org/jboss/pnc/dingrogu/api/dto/workflow/RepositoryCreationDTO.java
@@ -20,4 +20,6 @@ public class RepositoryCreationDTO {
     public JobNotificationType jobNotificationType;
     public BuildConfiguration buildConfiguration;
 
+    // Needed for notification purposes. Perhaps we can switch to operationId in the future
+    public String taskId;
 }

--- a/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/workflows/RepositoryCreationWorkflow.java
+++ b/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/workflows/RepositoryCreationWorkflow.java
@@ -191,7 +191,7 @@ public class RepositoryCreationWorkflow implements Workflow<RepositoryCreationDT
                     .internalScmUrl(creationResponse.get().getReadwriteUrl())
                     .externalUrl(dto.getExternalRepoUrl())
                     .preBuildSyncEnabled(dto.isPreBuildSyncEnabled())
-                    // .taskId(dto.getTaskId())
+                    .taskId(Long.parseLong(dto.getTaskId()))
                     .jobType(convertJobType(dto.getJobNotificationType()))
                     .buildConfiguration(dto.getBuildConfiguration())
                     .build();


### PR DESCRIPTION
This is needed so that Orch sends the proper notification in the UI that the scm creation is done.

In the future, we can move to the operation id, but for now we use this to be backwards compatible with BPM.