### PR TITLE
[NCL-9117] Use new Rex milestone feature

### DIFF
--- a/api/src/main/java/org/jboss/pnc/dingrogu/api/dto/workflow/BuildWorkflowClearEnvironmentDTO.java
+++ b/api/src/main/java/org/jboss/pnc/dingrogu/api/dto/workflow/BuildWorkflowClearEnvironmentDTO.java
@@ -1,0 +1,13 @@
+package org.jboss.pnc.dingrogu.api.dto.workflow;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+
+@Jacksonized
+@Data
+@Builder
+public class BuildWorkflowClearEnvironmentDTO {
+    String environmentDriverUrl;
+    String correlationId;
+}

--- a/api/src/main/java/org/jboss/pnc/dingrogu/api/endpoint/WorkflowEndpoint.java
+++ b/api/src/main/java/org/jboss/pnc/dingrogu/api/endpoint/WorkflowEndpoint.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.pnc.dingrogu.api.dto.CorrelationId;
 import org.jboss.pnc.dingrogu.api.dto.workflow.BrewPushWorkflowDTO;
+import org.jboss.pnc.dingrogu.api.dto.workflow.BuildWorkflowClearEnvironmentDTO;
 import org.jboss.pnc.dingrogu.api.dto.workflow.DeliverablesAnalysisWorkflowDTO;
 import org.jboss.pnc.dingrogu.api.dto.workflow.DummyWorkflowDTO;
 import org.jboss.pnc.dingrogu.api.dto.workflow.RepositoryCreationDTO;
@@ -31,6 +32,7 @@ public interface WorkflowEndpoint {
     String BREW_PUSH_REX_NOTIFY = "/workflow/brew-push/rex-notify";
     String REPOSITORY_CREATION_REX_NOTIFY = "/workflow/repository-creation/rex-notify";
     String BUILD_REX_NOTIFY = "/workflow/build/rex-notify";
+    String BUILD_CLEAR_ENVIRONMENT = "/workflow/build/clear-environment";
     String DELIVERABLES_ANALYSIS_REX_NOTIFY = "/workflow/deliverables-analysis/rex-notify";
     String DUMMY_REX_NOTIFY = "/workflow/dummy/rex-notify";
 
@@ -76,6 +78,11 @@ public interface WorkflowEndpoint {
     @POST
     @RolesAllowed({ AuthorizationConstants.ADMIN_ROLE, AuthorizationConstants.DINGROGU_ROLE })
     CorrelationId startBuildWorkflowFromRex(StartRequest startRequest);
+
+    @Path(BUILD_CLEAR_ENVIRONMENT)
+    @POST
+    @RolesAllowed({ AuthorizationConstants.ADMIN_ROLE, AuthorizationConstants.DINGROGU_ROLE })
+    void buildWorkflowClearEnvironment(BuildWorkflowClearEnvironmentDTO buildWorkflowClearEnvironmentDTO);
 
     @Path(BUILD_REX_NOTIFY)
     @POST

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version.javadoc.plugin>3.11.2</version.javadoc.plugin>
         <version.source.plugin>3.3.1</version.source.plugin>
         <version.pnc>3.1.5</version.pnc>
-        <version.rex>1.0.3</version.rex>
+        <version.rex>1.0.4-SNAPSHOT</version.rex>
     </properties>
 
     <packaging>pom</packaging>

--- a/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/Adapter.java
+++ b/rest-adapter/src/main/java/org/jboss/pnc/dingrogu/restadapter/adapter/Adapter.java
@@ -93,6 +93,57 @@ public interface Adapter<T> {
      */
     default CreateTaskDTO generateRexTask(String adapterUrl, String correlationId, Object notificationAttachment, T t)
             throws Exception {
+        return generateRexTask(adapterUrl, correlationId, notificationAttachment, t, null, null);
+
+    }
+
+    /**
+     * Generate the Rex Task DTO. That Rex task should communicate to the adapter endpoint. The task retries itself in
+     * case of failure
+     *
+     * @param adapterUrl
+     * @param correlationId
+     * @param notificationAttachment
+     * @param t data needed to generate the rex task
+     * @return Rex task
+     * @throws Exception if something went wrong
+     */
+    default CreateTaskDTO generateRexTaskRetryItself(
+            String adapterUrl,
+            String correlationId,
+            Object notificationAttachment,
+            T t)
+            throws Exception {
+        return generateRexTask(
+                adapterUrl,
+                correlationId,
+                notificationAttachment,
+                t,
+                getRexTaskName(correlationId),
+                null);
+
+    }
+
+    /**
+     * Generate the Rex Task DTO. That Rex task should communicate to the adapter endpoint
+     *
+     * @param adapterUrl
+     * @param correlationId
+     * @param notificationAttachment
+     * @param t data needed to generate the rex task
+     * @param milestoneTask task to rollback to in case of faillure
+     * @param rollbackRequest request to send when rollback happens
+     * @return Rex task
+     * @throws Exception if something went wrong
+     */
+    default CreateTaskDTO generateRexTask(
+            String adapterUrl,
+            String correlationId,
+            Object notificationAttachment,
+            T t,
+            String milestoneTask,
+            Request rollbackRequest)
+            throws Exception {
 
         Request startAdjust = new Request(
                 Request.Method.POST,
@@ -117,6 +168,8 @@ public interface Adapter<T> {
                 .remoteStart(startAdjust)
                 .remoteCancel(cancelAdjust)
                 .callerNotifications(callerNotification)
+                .milestoneTask(milestoneTask)
+                .remoteRollback(rollbackRequest)
                 .configuration(
                         ConfigurationDTO.builder()
                                 .passResultsOfDependencies(shouldGetResultsFromDependencies())

--- a/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/rest/WorkflowEndpointImpl.java
+++ b/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/rest/WorkflowEndpointImpl.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.jboss.pnc.dingrogu.api.dto.CorrelationId;
 import org.jboss.pnc.dingrogu.api.dto.workflow.BrewPushWorkflowDTO;
+import org.jboss.pnc.dingrogu.api.dto.workflow.BuildWorkflowClearEnvironmentDTO;
 import org.jboss.pnc.dingrogu.api.dto.workflow.DeliverablesAnalysisWorkflowDTO;
 import org.jboss.pnc.dingrogu.api.dto.workflow.DummyWorkflowDTO;
 import org.jboss.pnc.dingrogu.api.dto.workflow.RepositoryCreationDTO;
@@ -64,6 +65,11 @@ public class WorkflowEndpointImpl implements WorkflowEndpoint {
     @Override
     public CorrelationId startBuildWorkflowFromRex(StartRequest startRequest) {
         return buildWorkflow.submitWorkflow(startRequest);
+    }
+
+    @Override
+    public void buildWorkflowClearEnvironment(BuildWorkflowClearEnvironmentDTO buildWorkflowClearEnvironmentDTO) {
+        buildWorkflow.clearEnvironment(buildWorkflowClearEnvironmentDTO);
     }
 
     @Override

--- a/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/workflows/DeliverablesAnalysisWorkflow.java
+++ b/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/workflows/DeliverablesAnalysisWorkflow.java
@@ -96,7 +96,7 @@ public class DeliverablesAnalysisWorkflow implements Workflow<DeliverablesAnalys
 
         try {
             CreateTaskDTO taskAnalyze = deliverablesAnalyzerAdapter
-                    .generateRexTask(ownUrl, correlationId.getId(), dto, delaDTO);
+                    .generateRexTaskRetryItself(ownUrl, correlationId.getId(), dto, delaDTO);
 
             CreateTaskDTO taskResult = orchAdapter.generateRexTask(ownUrl, correlationId.getId(), dto, orchResultDTO);
 


### PR DESCRIPTION
- Deliverables analyzer "analyze" now retries by itself
- Build process:
  * reqour process now retries by itself
  * environment driver setup now retries by itself
  * if the build step fails, the environment is cleared and we revert back to repository setup

An extra REST endpoint ("/workflow/build/clear-environment") is introduced so that on the build step failure, this endpoint is used by Rex during the rollback process to clear the environment.