### PR TITLE
Fix stacktrace on cancel error

### DIFF
--- a/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/rest/WorkflowEndpointImpl.java
+++ b/rest-workflow/src/main/java/org/jboss/pnc/dingrogu/restworkflow/rest/WorkflowEndpointImpl.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.rex.api.TaskEndpoint;
 import org.jboss.pnc.rex.dto.TaskDTO;
 import org.jboss.pnc.rex.model.requests.NotificationRequest;
 import org.jboss.pnc.rex.model.requests.StartRequest;
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
 
 import io.quarkus.logging.Log;
 
@@ -119,6 +120,8 @@ public class WorkflowEndpointImpl implements WorkflowEndpoint {
                     if (response.getStatus() != Response.Status.ACCEPTED.getStatusCode()) {
                         Log.warnf("Couldn't cancel Rex task: %s", task.getName());
                     }
+                } catch (ClientWebApplicationException e) {
+                    Log.warnf("Couldn't cancel Rex task: %s with exception %s", task.getName(), e.getMessage());
                 }
             }
         }


### PR DESCRIPTION
It's ok if some tasks fail with error 400. They are probably already cancelled.