### PR TITLE
Increase the max-body-size to 100M

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -18,6 +18,9 @@ rexclient:
     queue_size: 10
 
 quarkus:
+  http:
+    limits:
+      max-body-size: 100M
   arc:
     # Do not remove the adapter implementations since we'll dynamically use them in the adapter endpoint
     unremovable-types: org.jboss.pnc.dingrogu.restadapter.adapter.**


### PR DESCRIPTION
This is to accept those big JSON files from repository-driver during the promotion process.