### PR TITLE
[NCL-9834] Bump pnc-api to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version.javadoc.plugin>3.12.0</version.javadoc.plugin>
         <version.source.plugin>3.4.0</version.source.plugin>
         <version.pnc>3.5.3</version.pnc>
-        <version.pnc-api>3.5.1</version.pnc-api>
+        <version.pnc-api>3.5.2</version.pnc-api>
         <version.pnc-common>3.5.1</version.pnc-common>
         <version.rex>1.2.3</version.rex>
         <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
Required to get the new build category LIGHTWELL_NOVEL